### PR TITLE
Add a pass to Symfony project to update database schema using doctrine

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -5,6 +5,7 @@ import os
 import sys
 import inspect
 import json
+
 from utils import stdio
 from utils.stdio import CRESET, CBOLD, LGREEN
 import plugins
@@ -95,15 +96,14 @@ def release(project_path):
     print(CBOLD+LGREEN, "\n==> {} successfully deployed. Have an A1 day!\n".format(project_path), CRESET)
 
 
-
 # Here goes the code
-
+sanitized_root_dir = os.path.expanduser(ROOT_DIR.strip('/'))
 projects = []
 # Get all projects for ROOT_DIR
-for dir_name in os.listdir(ROOT_DIR):
-    if os.path.isdir(ROOT_DIR + dir_name):
-        dir_path = ROOT_DIR + dir_name
-        config_file_path = dir_path + "/" + CONFIG_FILE_NAME
+for dir_name in os.listdir(sanitized_root_dir):
+    dir_path = os.path.join(sanitized_root_dir, dir_name)
+    if os.path.isdir(dir_path):
+        config_file_path = os.path.join(dir_path, CONFIG_FILE_NAME)
 
         # Look for config file for this project
         if os.path.exists(config_file_path) and os.path.isfile(config_file_path):
@@ -127,7 +127,7 @@ if args.all:
             print(CBOLD+LGREEN, "\nDeploying project {} ({})".format(project_name, target_branch), CRESET)
             release(project)
     else:
-        print("There is no suitable project in {}".format(ROOT_DIR))
+        print("There is no suitable project in {}".format(sanitized_root_dir))
 
 elif args.project == 'ask_for_it':
     print("Please select a project to sync")
@@ -162,7 +162,7 @@ else:
             print("\"{}\" is not a directory".format(project_path))
             sys.exit(1)
     else:
-        project_path = os.path.join(ROOT_DIR, args.project)
+        project_path = os.path.join(sanitized_root_dir, args.project)
 
         if project_path not in projects:
             print("Project not found")

--- a/plugins/symfony.py
+++ b/plugins/symfony.py
@@ -8,7 +8,7 @@ def register_variants():
 
 class Symfony:
     def register_passes(self):
-        return ['composer', '?scss', 'assets', 'cache', '?liip_imagine_cache']
+        return ['composer', '?scss', 'assets', 'cache', '?liip_imagine_cache', '?update_database_schema']
 
     def composer_pass(self):
         if os.path.isfile("composer.phar"):
@@ -35,6 +35,10 @@ class Symfony:
                 if file.endswith(".scss") and not file.startswith("_"): # Exclude SCSS part files (_part.scss)
                     abs_path = os.path.join(root, file)
                     stdio.ppexec("sass " + abs_path + " " + abs_path.replace(".scss", ".css") + " --style compressed")
+
+    def update_database_schema_pass(self):
+        stdio.ppexec(self.app_console + " doctrine:schema:update --force")
+
 
 class Symfony2(Symfony):
     key_name = "symfony2"


### PR DESCRIPTION
The new `Symfony.update_database_schema_pass` method runs `php app/console doctrine:schema:update --force`. It's disabled by default.
I removed the `read_conf` function which did what [dict.get](https://docs.python.org/3/library/stdtypes.html#dict.get) does.
Also, I fixed the handling of `ROOT_DIR` so that you can use `~` and don't have to specify the trailing `/` (but it will also work if you do specify it, **thanks [Obama](https://docs.python.org/3/library/os.path.html#os.path.join)**).

As a proof, this pull-request ends on a trailing slash.

![trailing slash](http://lh5.ggpht.com/jBR2koWhzJoVpC7Zik0kMqmGwqvSUrygg9EiXGAm-DPxTQN95EDv5__bHaiTMHc5I2o72fN1D1WuEDNPBjjnfWGE=s200)
