### PR TITLE
fix ROOT_DIR stripping

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -92,7 +92,7 @@ def release(project_path):
 
 
 # Here goes the code
-sanitized_root_dir = os.path.expanduser(ROOT_DIR.strip('/'))
+sanitized_root_dir = os.path.expanduser(ROOT_DIR.rstrip('/'))
 projects = []
 # Get all projects for ROOT_DIR
 for dir_name in os.listdir(sanitized_root_dir):


### PR DESCRIPTION
Oops, my bad... I used `strip` to remove the trailing slash when I should have used `rstrip`, because `strip` will also remove the starting slash if `ROOT_DIR` is an absolute path. Sorry about this one.
Next :beers: on me !
